### PR TITLE
rename module to gopkg.in/hairyhenderson/yaml.v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ go:
     - 1.9
     - tip
 
-go_import_path: gopkg.in/yaml.v2
+go_import_path: gopkg.in/hairyhenderson/yaml.v2

--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ supported since they're a poor design and are gone in YAML 1.2.
 Installation and usage
 ----------------------
 
-The import path for the package is *gopkg.in/yaml.v2*.
+The import path for the package is *gopkg.in/hairyhenderson/yaml.v2*.
 
 To install it, run:
 
-    go get gopkg.in/yaml.v2
+    go get gopkg.in/hairyhenderson/yaml.v2
 
 API documentation
 -----------------
 
 If opened in a browser, the import path itself leads to the API documentation:
 
-  * [https://gopkg.in/yaml.v2](https://gopkg.in/yaml.v2)
+  * [https://gopkg.in/hairyhenderson/yaml.v2](https://gopkg.in/hairyhenderson/yaml.v2)
 
 API stability
 -------------
@@ -55,7 +55,7 @@ import (
         "fmt"
         "log"
 
-        "gopkg.in/yaml.v2"
+        "gopkg.in/hairyhenderson/yaml.v2"
 )
 
 var data = `

--- a/decode_test.go
+++ b/decode_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/hairyhenderson/yaml.v2"
 )
 
 var unmarshalIntTest = 123

--- a/encode_test.go
+++ b/encode_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/hairyhenderson/yaml.v2"
 )
 
 type jsonNumberT string

--- a/example_embedded_test.go
+++ b/example_embedded_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/hairyhenderson/yaml.v2"
 )
 
 // An example showing how to unmarshal embedded

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module "gopkg.in/yaml.v2"
+module "gopkg.in/hairyhenderson/yaml.v2"
 
 require (
 	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405

--- a/yaml.go
+++ b/yaml.go
@@ -15,6 +15,15 @@ import (
 	"sync"
 )
 
+// DefaultMapType contains the type that YAML maps are decoded to
+//
+// This is a hack that can be undone once gopkg.in/yaml.v3 is available
+// See https://github.com/go-yaml/yaml/issues/139
+// I stole this from github.com/superwhiskers/yaml
+// To use this:
+//    *yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
+var DefaultMapType = &defaultMapType
+
 // MapSlice encodes and decodes as a YAML map.
 // The order of keys is preserved when encoding and decoding.
 type MapSlice []MapItem


### PR DESCRIPTION
this restores module support as go won't complain anymore about a
unexpected module path when including this in a go module